### PR TITLE
Add TxUncopy command

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,7 @@ Features:
 - send visually highlighted lines to the associated pane
 - send to pane by prompting for input
 - send to pane by setting a run command for the current filetype
+- cancel copy-mode on associated panes
 - once set, run commands are remembered, but can easily be reset
 - all the plugin configuration happens in one dictionary that holds filetypes as
   keys and run commands as values
@@ -87,6 +88,12 @@ Executes TxCreate. Creates a new pane and associates with it.
 ```
 
 Executes TxKill. Closes the associated pane.
+
+```vim
+<leader>mv
+```
+
+Executes :TxUncopy. Cancels copy mode in the associated pane.
 
 ```vim
 <leader>ms

--- a/autoload/tmuxify.vim
+++ b/autoload/tmuxify.vim
@@ -241,6 +241,28 @@ function! tmuxify#pane_send_raw(cmd, bang) abort
   call system('tmux send-keys -t '. pane_descriptor ." '". keys . "'")
 endfunction
 
+" tmuxify#pane_uncopy() {{{1
+function! tmuxify#pane_uncopy(bang) abort
+  if empty(a:bang)
+    let scope = "b:"
+  else
+    let scope = "g:"
+  endif
+
+  if !exists(scope . 'pane_id') && !tmuxify#pane_create(a:bang)
+    return
+  endif
+
+  execute 'let pane_id = ' scope . 'pane_id'
+  let pane_descriptor = s:get_pane_descriptor_from_id(pane_id)
+  if empty(pane_descriptor)
+    echomsg 'tmuxify: The associated pane was already closed! Run :TxCreate.'
+    return
+  endif
+
+  call system('tmux send-keys -t '. pane_descriptor ." -X cancel")
+endfunction
+
 " tmuxify#set_run_command_for_filetype() {{{1
 function! tmuxify#set_run_command_for_filetype(...) abort
   if !exists('g:tmuxify_run')

--- a/doc/tmuxify.txt
+++ b/doc/tmuxify.txt
@@ -46,6 +46,8 @@ tmuxify is a plugin for handling tmux panes:
 
   - send to pane by setting a run command for the current filetype
 
+  - cancel copy-mode on associated panes
+
   - once set, run commands are remembered, but can easily be reset
 
   - all the plugin configuration happens in one dictionary that holds
@@ -124,6 +126,12 @@ Executes :TxCreate. Creates a new pane and associates with it.
     <leader>mq
 <
 Executes :TxKill. Closes the associated pane.
+
+------------------------------------------------------------------------------
+>
+    <leader>mv
+<
+Executes :TxUncopy. Cancels copy mode in the associated pane.
 
 ------------------------------------------------------------------------------
 >

--- a/plugin/tmuxify.vim
+++ b/plugin/tmuxify.vim
@@ -14,6 +14,7 @@ let s:map_prefix = get(g:, 'tmuxify_map_prefix', '<leader>m')
 " commands {{{1
 command! -nargs=0 -bar -bang TxClear     call tmuxify#pane_send_raw('C-l', <q-bang>)
 command! -nargs=0 -bar -bang TxKill      call tmuxify#pane_kill(<q-bang>)
+command! -nargs=0 -bar -bang TxUncopy    call tmuxify#pane_uncopy(<q-bang>)
 command! -nargs=? -bar -bang TxSetPane   call tmuxify#pane_set(<q-bang>, <f-args>)
 command! -nargs=0 -bar -bang TxSigInt    call tmuxify#pane_send_raw('C-c', <q-bang>)
 command! -nargs=? -bar -bang TxCreate    call tmuxify#pane_create(<q-bang>, <args>)
@@ -29,6 +30,7 @@ if s:map_prefix !=# ""
   execute 'nnoremap <silent>' s:map_prefix .'n :TxCreate' . global . '<cr>'
   execute 'nnoremap <silent>' s:map_prefix .'p :TxSetPane' . global . '<cr>'
   execute 'nnoremap <silent>' s:map_prefix .'q :TxKill' . global . '<cr>'
+  execute 'nnoremap <silent>' s:map_prefix .'v :TxUncopy' . global . '<cr>'
   execute 'nnoremap <silent>' s:map_prefix .'r :TxRun' . global . '<cr>'
   execute 'nnoremap <silent>' s:map_prefix .'s :TxSend' . global . '<cr>'
   execute 'nnoremap <silent>' s:map_prefix .'k :TxSendKey' . global . '<cr>'


### PR DESCRIPTION
This will cancel copy mode on the associated pane.

It used to be the case that sending a Ctrl-C to the associated pane would kick it out of copy-mode, but as of something around Tmux 3, that broke. This adds a new command that, in my testing, works reliably to kick the pane out of copy mode. This is particularly useful if you have scrolled up in that pane and want to bounce it back down to the bottom to receive some new command.

Lemme know if the name "uncopy" is terrible, I am not in love with it.